### PR TITLE
Set default advanced options to aws_elasticsearch_domain configuratio…

### DIFF
--- a/es.tf
+++ b/es.tf
@@ -52,7 +52,7 @@ module "es" {
     security_group_ids = ["${aws_security_group.es_allow_all.id}"]
     subnet_ids         = "${var.vpc_subnet_ids}"
   }
-
+  advanced_options      = var.advanced_options
   es_version            = "${var.es_version}"
   instance_count        = "${var.instance_count}"
   instance_type         = "${var.instance_type}"

--- a/variables.tf
+++ b/variables.tf
@@ -56,3 +56,9 @@ variable "es_version" {
   description = "The elastic search version to be used."
   default     = 6.3
 }
+
+variable "advanced_options" {
+  description = "Map of key-value string pairs to specify advanced configuration options. Note that the values for these configuration options must be strings (wrapped in quotes) or they may be wrong and cause a perpetual diff, causing Terraform to want to recreate your Elasticsearch domain on every apply."
+  type        = map(string)
+  default     = {"rest.action.multi.allow_explicit_index" = "true"}
+}


### PR DESCRIPTION
…n to prevent a perpetual diff causing Terraform to recreate our Elasticsearch domain on every apply